### PR TITLE
Fix Config File Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.ap
  - Windows: `%LOCALAPPDATA%\JellyfinMediaPlayer\logs`
  - Linux: `~/.local/share/jellyfinmediaplayer/logs/`
  - Linux (Flatpak): `~/.var/app/com.github.iwalton3.jellyfin-media-player/data/jellyfinmediaplayer/logs/`
- - macOS: `~/Library/Logs/Jellyfin Media Player/`
+ - macOS: `~/Library/Logs/Terminus Player/`
 
 ## Config File Location
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The main configuration file is called `jellyfinmediaplayer.conf`. You can also a
  - Windows: `%LOCALAPPDATA%\JellyfinMediaPlayer\`
  - Linux: `~/.local/share/jellyfinmediaplayer/`
  - Linux (Flatpak): `~/.var/app/com.github.iwalton3.jellyfin-media-player/data/jellyfinmediaplayer/`
- - macOS: `~/Library/Application Support/Jellyfin Media Player/`
+ - macOS: `~/Library/Application Support/Terminus Player/`
 
 ## Web Debugger
 


### PR DESCRIPTION
I noticed that there was only a **Terminus Player** in the Application Support folder, but no **Jellyfin Media Player**. And so does Log File. To avoid confusion, I suggest correcting this error in the readme file:
Replace `~/Library/Application Support/Jellyfin Media Player/` to `~/Library/Application Support/Terminus Player/`
Replace `~/Library/Logs/Jellyfin Media Player/` to `~/Library/Logs/Terminus Player/`